### PR TITLE
Updated result parsing to `JArray.Parse`

### DIFF
--- a/validate/AccuracyTest.cs
+++ b/validate/AccuracyTest.cs
@@ -68,7 +68,7 @@ public sealed class AccuracyTest
         }
 
         string expectedJson = File.ReadAllText(resultFile!);
-        var expected = JToken.Parse(expectedJson);
+        var expected = JArray.Parse(expectedJson);
 
         bool equivalent = JToken.DeepEquals(expected, result);
         Assert.True(equivalent);


### PR DESCRIPTION
Previously, resulting parsing used `JToken.Parse` which does not make the intention clear.